### PR TITLE
feat: 支持 node modules config

### DIFF
--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -6,6 +6,7 @@ const Path = require('path');
 const { js_beautify: beautify } = require('js-beautify');
 const requireFromUrl = require('require-from-url/sync');
 require('require-yaml');
+const { spawnSync } = require('child_process');
 
 /**
  * Sort an object by its keys
@@ -307,7 +308,16 @@ function cleanConfig(confirm, path = process.cwd()) {
 function getRemoteUrl(path) {
     const pkgPath = Path.join(path, 'package.json');
     const pkgExist = fs.existsSync(pkgPath);
-    const { gren = '' } = pkgExist ? require(pkgPath) : {};
+    if (!pkgExist) return '';
+    let {gren} = require(pkgPath);
+    if (!gren.startsWith('http')) {
+        const { stdout } = spawnSync('node', ['get-package-latest-version.js', gren], {
+            cwd: __dirname
+        });
+        const [errMsg, version] = JSON.parse(stdout.toString());
+        if (errMsg) throw new Error(errMsg);
+        gren = `https://cdn.jsdelivr.net/npm/${gren}@${version}/index.js`;
+    }
     return gren;
 }
 
@@ -316,7 +326,7 @@ function getRemoteUrl(path) {
  * @since 0.18.0
  * @private
  *
- * @param  {string} path Path where to look for config files
+ * @param  {string} url where to find the config file
  * @return {Object} The configuration from the first found file or empty object
 */
 function getConfigFromRemote(url) {

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -310,6 +310,7 @@ function getRemoteUrl(path) {
     const pkgExist = fs.existsSync(pkgPath);
     if (!pkgExist) return '';
     let {gren} = require(pkgPath);
+    if (!gren) return '';
     if (!gren.startsWith('http')) {
         const { stdout } = spawnSync('node', ['get-package-latest-version.js', gren], {
             cwd: __dirname

--- a/lib/src/get-package-latest-version.js
+++ b/lib/src/get-package-latest-version.js
@@ -1,0 +1,19 @@
+const https = require('https');
+
+const packageName = process.argv[2];
+const url = `https://registry.npmjs.org/-/package/${packageName}/dist-tags`;
+https.get(url, res => {
+    const buffers = [];
+    res.on('data', (data) => {
+        buffers.push(data);
+    }).on('end', () => {
+        const result = [];
+        if (res.statusCode !== 200) {
+            result.push(`url: ${url}; statusCode: ${res.statusCode}`);
+        } else {
+            const { latest } = JSON.parse(Buffer.concat(buffers).toString());
+            result.push(null, latest);
+        }
+        process.stdout.write(JSON.stringify(result));
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "github-release-notes",
+    "name": "@femessage/github-release-notes",
     "version": "0.18.0",
     "lockfileVersion": 1,
     "requires": true,

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "yamljs": "^0.3.0"
     },
     "publishConfig": {
-      "access": "public"
+        "access": "public"
     },
     "gren": "https://raw.githubusercontent.com/FEMessage/.github/master/.grenrc.js"
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,5 @@
     },
     "publishConfig": {
         "access": "public"
-    },
-    "gren": "https://raw.githubusercontent.com/FEMessage/.github/master/.grenrc.js"
+    }
 }

--- a/test/GitHubInfo.spec.js
+++ b/test/GitHubInfo.spec.js
@@ -16,7 +16,7 @@ describe('GitHubInfo', () => {
 
     it('Should get repo and token informations', () => {
         githubInfo.repo.then(({ username, repo }) => {
-            assert.deepEqual(username, 'github-tools', 'Get username from repo\'s folder');
+            assert.deepEqual(username, 'FEMessage', 'Get username from repo\'s folder');
             assert.deepEqual(repo, 'github-release-notes', 'Get the repository name from repo\'s folder');
         });
 

--- a/test/Program.spec.js
+++ b/test/Program.spec.js
@@ -1,6 +1,5 @@
 import { assert } from 'chai';
 import Program from '../lib/src/Program.js';
-import testCommand from 'commander';
 
 describe('Program', () => {
     const testCommand = new Program({

--- a/test/_utils.spec.js
+++ b/test/_utils.spec.js
@@ -177,16 +177,15 @@ describe('_utils.js', () => {
     describe('getRemoteUrl', () => {
         const filename = process.cwd() + '/test/.temp/package.json';
         const fileContent = {
-            gren: 'testUri'
+            gren: '@femessage/grenrc'
         };
 
         beforeEach(() => {
             fs.writeFileSync(filename, JSON.stringify(fileContent));
         });
 
-        it('Should always return a String', () => {
+        it('Should return a String', () => {
             assert.isOk(typeof utils.getRemoteUrl(process.cwd() + '/test/.temp') === 'string', 'The type is a string');
-            assert.deepEqual(utils.getRemoteUrl(process.cwd() + '/test/.temp'), fileContent.gren, 'Given the right package path');
             assert.deepEqual(utils.getRemoteUrl(process.cwd() + '/test'), '', 'Given a path with no package.json');
         });
 
@@ -196,11 +195,10 @@ describe('_utils.js', () => {
     });
 
     describe('getConfigFromRemote', () => {
-        const grenRemote = 'https://raw.githubusercontent.com/FEMessage/github-release-notes/master/.grenrc.js';
-        const grenrc = require(process.cwd() + '/.grenrc.js');
+        const grenRemote = 'https://cdn.jsdelivr.net/npm/@femessage/grenrc@1.0.1/index.js';
 
         it('Should fetch config from remote url', () => {
-            assert.deepEqual(utils.getConfigFromRemote(grenRemote), grenrc, 'Given a remote gren config');
+            assert.isOk(typeof utils.getConfigFromRemote(grenRemote) === 'object', 'Given a remote gren config');
         });
     });
 


### PR DESCRIPTION
## How
参考 require-from-url 源码；使用 child_process 来模拟同步请求。
1. 从 npm 获取包最新版号
2. 拼接 jsdelivr 链接

## Test
1. npm link，可将 bin 链接到全局 bin 目录下。通过运行`gren -v`确认成功（yarn link 无此功能）
2. 在 upload-to-ali 提 pr & 打 tag，模拟发版
3. 在 upload-to-ali 运行`gren release --override`

![image](https://user-images.githubusercontent.com/19591950/70844856-1085b000-1e82-11ea-9957-8c7dc7eccffa.png)
![image](https://user-images.githubusercontent.com/19591950/70845441-d6201100-1e89-11ea-92d6-4f8f7355cecf.png)

![image](https://user-images.githubusercontent.com/19591950/70844873-5e9ab380-1e82-11ea-8863-1b31a21e5216.png)

### 更新在线配置，能立即获取最新版
![image](https://user-images.githubusercontent.com/19591950/70889879-92aadb80-201e-11ea-90a5-c79906d6439c.png)
